### PR TITLE
Deploy config templates for Apache and DC/OS services

### DIFF
--- a/deploy/deploy_apache_mesosturbo_5.9_latest.json
+++ b/deploy/deploy_apache_mesosturbo_5.9_latest.json
@@ -8,8 +8,8 @@
     "volumes": []
   },
   "args": [
-    "--mesostype", "Mesosphere DCOS",
-    "--masterip", "<MESOS-MASTER-IP>"
+    "--mesostype", "Apache Mesos",
+    "--masterip", "<MESOS-MASTER-IP>",
     "--masterport", "<MESOS-MASTER-PORT>",
     "--masteruser", "<MESOS-MASTER-USER>",
     "--masterpwd", "<MESOS-MASTER-PASSWORD>",

--- a/deploy/deploy_dcos_mesosturbo_5.9_latest.json
+++ b/deploy/deploy_dcos_mesosturbo_5.9_latest.json
@@ -1,0 +1,24 @@
+{
+  "id": "mesosturbo",
+  "container": {
+    "docker": {
+      "image": "vmturbo/mesosturbo:5.9-latest"
+    },
+    "type": "DOCKER",
+    "volumes": []
+  },
+  "args": [
+    "--mesostype", "Mesosphere DCOS",
+    "--masterip", "<MESOS-MASTER-IP>",
+    "--masterport", "<MESOS-MASTER-PORT>",
+    "--masteruser", "<MESOS-MASTER-USER>",
+    "--masterpwd", "<MESOS-MASTER-PASSWORD>",
+    "--turboserverurl", "http://<TURBO-OPERATIONS-MANAGER-IP>:80",
+    "--opsmanagerusername", "<TURBO-OPERATIONS-MANAGER-ADMIN-USERNAME>",
+    "--opsmanagerpassword", "<TURBO-OPERATIONS-MANAGER-ADMIN-PASSWORD>"
+  ],
+  "cpus": 0.5,
+  "mem": 128.0,
+  "instances": 1
+}
+


### PR DESCRIPTION
Added separate files for configuration to be used while deploying mesosturbo in Apache and DC/OS Mesos.