### PR TITLE
Support for leader election using Apache Mesos 1.2

### DIFF
--- a/cmd/conf-files/apache-mesos-target-conf-template.json
+++ b/cmd/conf-files/apache-mesos-target-conf-template.json
@@ -1,7 +1,6 @@
 {
   "master": "Apache Mesos",
-  "master-ip": "<Mesos Master IP>",
-  "master-port": "<Mesos Master Port>",
+  "master-ipport": "<Comma separated list of host and port of each Mesos Master in the cluster>",
   "master-user": "<Mesos Master Username>",
   "master-pwd": "<Mesos Master Password>"
 }

--- a/cmd/conf-files/dcos-target-conf-template.json
+++ b/cmd/conf-files/dcos-target-conf-template.json
@@ -1,7 +1,6 @@
 {
   "master": "Mesosphere DCOS",
-  "master-ip": "<Mesos Master IP>",
-  "master-port": "",
+  "master-ipport": "<Comma separated list of host and port of each Mesos Master in the cluster>",
   "master-user": "<Mesos Master Username>",
   "master-pwd": "<Mesos Master Password>"
 }

--- a/cmd/service/mesosturbo_service.go
+++ b/cmd/service/mesosturbo_service.go
@@ -16,19 +16,18 @@ import (
 
 // VMTServer has all the context and params needed to run a Scheduler
 type MesosTurboService struct {
-	LogVersion int
+	LogVersion         int
 	MesosMasterConfig  string	//path to the mesos master config
 	TurboCommConfig    string	// path to the turbo communication config file
 
 	// config for mesos
-	Master         string
-	MasterIP       string
-	MasterPort     string
-	MasterUsername string
-	MasterPassword string
+	Master             string
+	MasterIPPort       string
+	MasterUsername     string
+	MasterPassword     string
 
 	// config for turbo server
-	TurboServerUrl 	   string
+	TurboServerUrl     string
 	OpsManagerUsername string
 	OpsManagerPassword string
 }
@@ -46,8 +45,7 @@ func (s *MesosTurboService) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&s.TurboCommConfig, "turboconfig", s.TurboCommConfig, "Path to the turbo config flag.")
 
 	fs.StringVar(&s.Master, "mesostype", s.Master, "Mesos Master Type 'Apache Mesos'|'Mesosphere DCOS'")
-	fs.StringVar(&s.MasterIP, "masterip", s.MasterIP, "IP for the Mesos Master")
-	fs.StringVar(&s.MasterPort, "masterport", s.MasterPort, "Port for the Mesos Master")
+	fs.StringVar(&s.MasterIPPort, "masteripport", s.MasterIPPort, "Comma separated list of IP:port of each Mesos Master in the cluster")
 	fs.StringVar(&s.MasterUsername, "masteruser", s.MasterUsername, "User for the Mesos Master")
 	fs.StringVar(&s.MasterPassword, "masterpwd", s.MasterPassword, "Password for the Mesos Master")
 
@@ -67,6 +65,7 @@ func (s *MesosTurboService) Run(_ []string) error {
 	// ----------- Mesos Target Config
 	var mesosTargetConf *conf.MesosTargetConf
 	var mesosConfErr error
+
 	if targetConf != "" {
 		mesosTargetConf, mesosConfErr = conf.NewMesosTargetConf(targetConf)
 	} else {
@@ -81,14 +80,14 @@ func (s *MesosTurboService) Run(_ []string) error {
 		if (master == "") {
 			mesosConfErr = fmt.Errorf("Mesos Master Type is required")
 		}
-		if (s.MasterIP == "") {
-			mesosConfErr = fmt.Errorf("Mesos Master IP is required")
+
+		if (s.MasterIPPort == "") {
+			mesosConfErr = fmt.Errorf("Mesos Master IP::Port list is required")
 		}
 
 		mesosTargetConf = &conf.MesosTargetConf{
 			Master: master,
-			MasterIP: s.MasterIP,
-			MasterPort: s.MasterPort,
+			MasterIPPort: s.MasterIPPort,
 			MasterUsername: s.MasterUsername,
 			MasterPassword: s.MasterPassword,
 		}
@@ -138,11 +137,11 @@ func (s *MesosTurboService) Run(_ []string) error {
 	discoveryClient, err := discovery.NewDiscoveryClient(mesosMasterType, mesosTargetConf)
 
 	if err != nil {
-		glog.Errorf("Error creating discovery client for "+string(mesosMasterType)+"::"+mesosTargetConf.MasterIP+"\n", err.Error())
+		glog.Errorf("Error creating discovery client for "+string(mesosMasterType)+"::"+mesosTargetConf.LeaderIP +"\n", err.Error())
 		os.Exit(1)
 	}
 
-	mesosTarget := mesosTargetConf.MasterIP
+	mesosTarget := mesosTargetConf.MasterIPPort
 	tapService, err :=
 		service.NewTAPServiceBuilder().
 			WithTurboCommunicator(turboCommConfigData).

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -3,7 +3,7 @@ Once deployed, the Mesosturbo service enables you to give Turbonomic visibility 
 
 ### Prerequisites
 * Turbonomic 5.9+
-* Running Mesos Apache or Mesosphere DCOS 1.8
+* Running Mesos Apache 1.2 or Mesosphere DCOS 1.8
 
 ### Step One: Deploying the Mesosturbo Docker Container Image
 > NOTE: Ensure that the Turbonomic Mesosturbo container image on DockerHub is accessible to the Marathon service in the Mesos Cluster.
@@ -32,8 +32,7 @@ A copy of the deploy config can be downloaded from [here](deploy_mesosturbo_5.9_
   },
   "args": [
     "--mesostype", "<MESOS MASTER TYPE>",
-    "--masterip", "<MESOS-MASTER-IP>"
-    "--masterport", "<MESOS-MASTER-PORT>",
+    "--masteripport", "<MESOS-MASTER-IPPORT>",
     "--masteruser", "<MESOS-MASTER-USER>",
     "--masterpwd", "<MESOS-MASTER-PASSWORD>",
     "--turboserverurl", "http://<TURBO-OPERATIONS-MANAGER-IP>:80",
@@ -50,8 +49,7 @@ A copy of the deploy config can be downloaded from [here](deploy_mesosturbo_5.9_
 > * \<MESOS MASTER TYPE> with 
 >   * "Mesosphere DCOS" for Mesosphere DC/OS 
 >   * "Apache Mesos" for Apache Mesos
-> * \<MESOS-MASTER-IP> with IP address for the Mesos Master
-> * \<MESOS-MASTER-PORT> with the port for the Mesos Master
+> * \<MESOS-MASTER-IPPORT> with the Comma separated list of host and port of each Mesos Master in the cluster
 > * \<MESOS-MASTER-USER> with the Username for the Mesos Master
 > * \<MESOS-MASTER-PASSWORD> with the Password for the Mesos Master
 > * \<TURBO-OPERATIONS-MANAGER-IP> with the IP address for the Turbo Operations Manager

--- a/deploy/deploy_apache_mesosturbo_5.9_latest.json
+++ b/deploy/deploy_apache_mesosturbo_5.9_latest.json
@@ -9,8 +9,7 @@
   },
   "args": [
     "--mesostype", "Apache Mesos",
-    "--masterip", "<MESOS-MASTER-IP>",
-    "--masterport", "<MESOS-MASTER-PORT>",
+    "--masteripport", "<MESOS-MASTER-IPPORT>",
     "--masteruser", "<MESOS-MASTER-USER>",
     "--masterpwd", "<MESOS-MASTER-PASSWORD>",
     "--turboserverurl", "http://<TURBO-OPERATIONS-MANAGER-IP>:80",

--- a/deploy/deploy_dcos_mesosturbo_5.9_latest.json
+++ b/deploy/deploy_dcos_mesosturbo_5.9_latest.json
@@ -9,8 +9,7 @@
   },
   "args": [
     "--mesostype", "Mesosphere DCOS",
-    "--masterip", "<MESOS-MASTER-IP>",
-    "--masterport", "<MESOS-MASTER-PORT>",
+    "--masteripport", "<MESOS-MASTER-IPPORT>",
     "--masteruser", "<MESOS-MASTER-USER>",
     "--masterpwd", "<MESOS-MASTER-PASSWORD>",
     "--turboserverurl", "http://<TURBO-OPERATIONS-MANAGER-IP>:80",

--- a/pkg/conf/mesos_target_conf_test.go
+++ b/pkg/conf/mesos_target_conf_test.go
@@ -14,21 +14,19 @@ func TestEmptyConfig(t *testing.T) {
 	assert.Equal(t, false, bool, fmt.Sprintf("Validation should fail for empty config : %s", err))
 }
 
-func TestMissingMasterIP(t *testing.T) {
+func TestMissingMasterIPPort(t *testing.T) {
 	conf := &MesosTargetConf{
-		MasterPort:     "8080",
 		MasterUsername: "user",
 		MasterPassword: "pwd",
 	}
 	bool, err := conf.validate()
 
-	assert.Equal(t, false, bool, fmt.Sprintf("Validation should fail for empty MasterIP : %s", err))
+	assert.Equal(t, false, bool, fmt.Sprintf("Validation should fail for empty MasterIPPort : %s", err))
 }
 
 func TestMissingMasterType(t *testing.T) {
 	conf := &MesosTargetConf{
-		MasterIP:       "127.0.0.1",
-		MasterPort:     "8080",
+		MasterIPPort:       "127.0.0.1:5050",
 		MasterUsername: "user",
 		MasterPassword: "pwd",
 	}
@@ -42,8 +40,7 @@ func TestMissingMasterType(t *testing.T) {
 func TestGetAccountFields(t *testing.T) {
 	conf := &MesosTargetConf{
 		Master:         Apache,
-		MasterIP:       "127.0.0.1",
-		MasterPort:     "8080",
+		MasterIPPort:       "127.0.0.1:5050",
 		MasterUsername: "user",
 		MasterPassword: "pwd",
 	}
@@ -56,8 +53,7 @@ func TestGetAccountFields(t *testing.T) {
 		acctValuesMap[acctVal.GetKey()] = acctVal
 	}
 
-	checkAccountValueField(t, acctValuesMap[string(MasterIP)], string(MasterIP), conf.MasterIP)
-	checkAccountValueField(t, acctValuesMap[string(MasterPort)], string(MasterPort), conf.MasterPort)
+	checkAccountValueField(t, acctValuesMap[string(MasterIPPort)], string(MasterIPPort), conf.MasterIPPort)
 	checkAccountValueField(t, acctValuesMap[string(MasterUsername)], string(MasterUsername), conf.MasterUsername)
 	checkAccountValueField(t, acctValuesMap[string(MasterPassword)], string(MasterPassword), conf.MasterPassword)
 }
@@ -79,19 +75,11 @@ func TestCreateMesosTargetConf(t *testing.T) {
 
 func createApacheAccValues() []*proto.AccountValue {
 	var accountValues []*proto.AccountValue
-	prop1 := string(MasterIP)
-	val1 := "10.10.10.10"
+	prop1 := string(MasterIPPort)
+	val1 := "10.10.10.10:5050"
 	accVal := &proto.AccountValue{
 		Key:         &prop1,
 		StringValue: &val1,
-	}
-	accountValues = append(accountValues, accVal)
-
-	prop2 := string(MasterPort)
-	val2 := "5050"
-	accVal = &proto.AccountValue{
-		Key:         &prop2,
-		StringValue: &val2,
 	}
 	accountValues = append(accountValues, accVal)
 

--- a/pkg/conf/probe_constants.go
+++ b/pkg/conf/probe_constants.go
@@ -28,8 +28,7 @@ const (
 type ProbeAcctDefEntryName string
 
 const (
-	MasterIP       ProbeAcctDefEntryName = "MasterIP"
-	MasterPort     ProbeAcctDefEntryName = "MasterPort"
+	MasterIPPort   	ProbeAcctDefEntryName = "MasterIPPort"
 	MasterUsername ProbeAcctDefEntryName = "Username"
 	MasterPassword ProbeAcctDefEntryName = "Password"
 
@@ -37,7 +36,4 @@ const (
 	FrameworkPort     ProbeAcctDefEntryName = "FrameworkPort"
 	FrameworkUsername ProbeAcctDefEntryName = "FrameworkUsername"
 	FrameworkPassword ProbeAcctDefEntryName = "FrameworkPassword"
-
-	ActionIP   ProbeAcctDefEntryName = "ActionIP"
-	ActionPort ProbeAcctDefEntryName = "ActionPort"
 )

--- a/pkg/data/types.go
+++ b/pkg/data/types.go
@@ -2,12 +2,18 @@ package data
 
 type MesosAPIResponse struct {
 	Leader      string `json:"leader"`
+	LeaderInfo struct {
+			   Id string `json:"id"`
+			   Pid string `json:"pid"`
+			   Port  int `json:"port"`
+			   Hostname string `json:"hostname"`
+	       } `json:"leader_info"`
 	Version     string `json:"version"`
 	Id          string `json:"id"`
 	ClusterName string `json:"cluster"`
 
-	ActivatedSlaves   float64     `json:"activated_slaves"`
-	DeActivatedSlaves float64     `json:"deactivated_slaves"`
+	//ActivatedSlaves   float64     `json:"activated_slaves"`
+	//DeActivatedSlaves float64     `json:"deactivated_slaves"`
 	Agents            []Agent     `json:"slaves"`
 	Frameworks        []Framework `json:"frameworks"`
 }
@@ -21,12 +27,12 @@ type Agent struct {
 	Name             string    `json:"hostname"`
 	//Calculated       CalculatedUse
 	//Attributes       Attributes `json:"attributes"`
-	Active  bool   `json:"active"`
-	Version string `json:"version"`
+	Active           bool   `json:"active"`
+	Version          string `json:"version"`
 	// -------- Computed parameters
-	ClusterName string
+	ClusterName      string
 	IP               string // parsed ip for the Slave
-	Port             string
+	PortNum          string
 	ResourceUseStats *CalculatedUse
 	TaskMap          map[string]*Task
 }

--- a/pkg/discovery/mesos_leader.go
+++ b/pkg/discovery/mesos_leader.go
@@ -1,0 +1,102 @@
+package discovery
+
+import (
+	"github.com/turbonomic/mesosturbo/pkg/conf"
+	master "github.com/turbonomic/mesosturbo/pkg/masterapi"
+	"fmt"
+	"strconv"
+	"strings"
+	"github.com/golang/glog"
+	"github.com/turbonomic/mesosturbo/pkg/data"
+)
+//
+//func main() {
+//	ipportlist := "10.10.174.92:5050,10.10.174.91:5050,10.10.174.100, 10.10.174.101:5050 "
+//	urlList := ParseMasterIPPorts(ipportlist)
+//	masteruser := "enlin.xu"
+//	masterpwd := "sysdreamworks"
+//	NewMesosCluster(conf.Apache, urlList, masteruser, masterpwd)
+//}
+//
+type MesosMasterUrl struct {
+	IP string
+	Port string
+}
+
+type MesosLeader struct {
+	leaderConf *conf.MesosTargetConf
+	MasterState *data.MesosAPIResponse
+}
+
+func NewMesosLeader(mesosMasterType conf.MesosMasterType, urlList []*MesosMasterUrl, masteruser, masterpwd string) (*MesosLeader, error) {
+	glog.Infof("Detecting mesos master leader from %s", urlList)
+	for _, ipport := range urlList {
+		glog.Infof("Check Master IPPort : %s\n", ipport)
+		clientConf := &conf.MesosTargetConf{
+			Master: mesosMasterType,
+			LeaderIP: ipport.IP,
+			LeaderPort: ipport.Port,
+			MasterUsername: masteruser,
+			MasterPassword: masterpwd,
+		}
+
+		masterRestClient := master.GetMasterRestClient(clientConf.Master, clientConf)
+		if masterRestClient == nil {
+			glog.Errorf("Cannot find RestClient for Mesos : " + string(clientConf.Master))
+			continue
+		}
+
+		// Login to the Mesos Master and save the login token
+		token, err := masterRestClient.Login()
+		if err != nil {
+			glog.Errorf("Error logging to Mesos Master at " +
+					clientConf.LeaderIP + "::" + clientConf.LeaderPort + " : ", err)
+			continue
+		}
+		clientConf.Token = token
+
+		mesosState, err := masterRestClient.GetState()
+		if err != nil {
+			glog.Errorf("Error getting state from master : %s \n", err)
+			continue
+		}
+		glog.V(3).Infof("Mesos API Succeeded for: %++v\n", mesosState.LeaderInfo)
+		// Leader is detected
+		clientConf.LeaderIP = mesosState.LeaderInfo.Hostname
+		clientConf.LeaderPort = strconv.Itoa(mesosState.LeaderInfo.Port)
+
+		mesosLeader := &MesosLeader{}
+		mesosLeader.leaderConf = clientConf
+		mesosLeader.MasterState = mesosState
+		glog.Infof("Detected Mesos Leader: %s::%s\n", mesosLeader.leaderConf.LeaderIP, mesosLeader.leaderConf.LeaderPort)
+		return mesosLeader, nil
+	}
+	return nil, fmt.Errorf("Cannot detect leader using %s", urlList)
+}
+
+func ParseMasterIPPorts(ipportlist string) []*MesosMasterUrl {
+	// Split on comma.
+	ipports := strings.Split(ipportlist, ",")
+
+	var urlList []*MesosMasterUrl
+	// Display all elements.
+	for i := range ipports {
+		fmt.Println("ipport=" + ipports[i])
+		result := strings.Split(ipports[i], ":")
+		var ipaddress, port string
+		ipaddress = strings.TrimSpace(result[0])
+		if len(result) < 2 {
+			port = conf.DEFAULT_MASTER_PORT
+		} else {
+			port = strings.TrimSpace(result[1])
+		}
+		ipport := &MesosMasterUrl{
+			IP:ipaddress,
+			Port:port,
+		}
+		urlList = append(urlList, ipport)
+	}
+	return urlList
+} //end
+
+

--- a/pkg/masterapi/agent_rest_api.go
+++ b/pkg/masterapi/agent_rest_api.go
@@ -58,7 +58,7 @@ func (agentRestClient *GenericAgentAPIClient) GetStats() ([]data.Executor, error
 	// Execute request
 	endpoint, _ := agentRestClient.EndpointStore.EndpointMap[Stats]
 	request, err := createRequest(endpoint.EndpointPath,
-					agentRestClient.AgentConf.AgentIP,  agentRestClient.AgentConf.AgentPort,
+					agentRestClient.AgentConf.AgentIP, string(agentRestClient.AgentConf.AgentPort),
 					agentRestClient.MasterConf.Token)
 	if err != nil {
 		return nil, ErrorCreateRequest(AgentAPIClientClass, err)

--- a/pkg/masterapi/master_rest_api.go
+++ b/pkg/masterapi/master_rest_api.go
@@ -111,7 +111,7 @@ func (mesosRestClient *GenericMasterAPIClient) GetState() (*data.MesosAPIRespons
 	// Execute request
 	endpoint, _ := mesosRestClient.EndpointStore.EndpointMap[State]
 	request, err := createRequest(endpoint.EndpointPath,
-				mesosRestClient.MesosConf.MasterIP, mesosRestClient.MesosConf.MasterPort,
+				mesosRestClient.MesosConf.LeaderIP, mesosRestClient.MesosConf.LeaderPort,
 				mesosRestClient.MesosConf.Token)
 	if err != nil {
 		return nil, ErrorCreateRequest(MesosMasterAPIClientClass, err)
@@ -187,7 +187,7 @@ func executeAndValidateResponse(request *http.Request, logPrefix string) ([]byte
 
 func (mesosRestClient *GenericMasterAPIClient) createLoginRequest(endpoint string) (*http.Request, error) {
 	var jsonStr []byte
-	url := "http://" + mesosRestClient.MesosConf.MasterIP + endpoint
+	url := "http://" + mesosRestClient.MesosConf.LeaderIP + endpoint
 
 	// Send user and password
 	jsonStr = []byte(`{"uid":"` + mesosRestClient.MesosConf.MasterUsername + `","password":"` + mesosRestClient.MesosConf.MasterPassword + `"}`)
@@ -217,22 +217,21 @@ func (mesosRestClient *GenericMasterAPIClient) getDebugModeState() ([]byte, erro
 // ========================================= State Request Parser ===================================================
 
 type GenericMasterStateParser struct {
-	//Message *conf.MesosState
 	Message *data.MesosAPIResponse
 }
 
 const GenericMasterStateParserClass = "[GenericMasterStateParser]"
 
 func (parser *GenericMasterStateParser) parseResponse(resp []byte) error {
-	glog.V(3).Infof(GenericMasterStateParserClass + " in parseAPIStateResponse")
+	glog.V(3).Infof("%s in parseAPIStateResponse : %s", GenericMasterStateParserClass, resp)
 	if resp == nil {
 		return ErrorEmptyResponse(GenericMasterStateParserClass)
 	}
 
-	var jsonMesosMaster data.MesosAPIResponse //conf.MesosState
+	var jsonMesosMaster data.MesosAPIResponse
 	err := json.Unmarshal(resp, &jsonMesosMaster)
 	if err != nil {
-		return fmt.Errorf(GenericMasterStateParserClass + " Error in json unmarshal for state response : %s", err)
+		return fmt.Errorf(GenericMasterStateParserClass + " Error in json unmarshal for state response : %s %+v", err, err)
 	}
 	parser.Message = &jsonMesosMaster
 	return nil

--- a/pkg/probe/registration_client.go
+++ b/pkg/probe/registration_client.go
@@ -131,7 +131,7 @@ func (registrationClient *MesosRegistrationClient) GetSupplyChainDefinition() []
 }
 
 func (registrationClient *MesosRegistrationClient) GetIdentifyingFields() string {
-	return string(conf.MasterIP)
+	return string(conf.MasterIPPort)
 }
 
 // The return type is a list of ProbeInfo_AccountDefProp.
@@ -140,19 +140,12 @@ func (registrationClient *MesosRegistrationClient) GetIdentifyingFields() string
 func (registrationClient *MesosRegistrationClient) GetAccountDefinition() []*proto.AccountDefEntry {
 	var acctDefProps []*proto.AccountDefEntry
 
-	// master ip
-	targetIDAcctDefEntry := builder.NewAccountDefEntryBuilder(string(conf.MasterIP), string(conf.MasterIP),
-		"IP of the mesos master", ".*",
+	// master ip port list
+	masterIPListAcctDefEntry := builder.NewAccountDefEntryBuilder(string(conf.MasterIPPort), string(conf.MasterIPPort),
+		"Comma separated list of `host:port` for each Mesos Master in the cluster", ".*",
 		true, false).
 		Create()
-	acctDefProps = append(acctDefProps, targetIDAcctDefEntry)
-
-	// master port
-	masterPortAcctDefEntry := builder.NewAccountDefEntryBuilder(string(conf.MasterPort), string(conf.MasterPort),
-		"Port of the mesos master", ".*",
-		false, false).
-		Create()
-	acctDefProps = append(acctDefProps, masterPortAcctDefEntry)
+	acctDefProps = append(acctDefProps, masterIPListAcctDefEntry)
 
 	// username
 	usernameAcctDefEntry := builder.NewAccountDefEntryBuilder(string(conf.MasterUsername), string(conf.MasterUsername),
@@ -168,48 +161,35 @@ func (registrationClient *MesosRegistrationClient) GetAccountDefinition() []*pro
 		Create()
 	acctDefProps = append(acctDefProps, passwdAcctDefEntry)
 
-	if registrationClient.mesosMasterType == conf.Apache {
-		// framework id
-		frameworkIpAcctDefEntry := builder.NewAccountDefEntryBuilder(string(conf.FrameworkIP), string(conf.FrameworkIP),
-			"IP for the Framework", ".*",
-			false, false).
-			Create()
-		acctDefProps = append(acctDefProps, frameworkIpAcctDefEntry)
-
-		// framework port
-		frameworkPortAcctDefEntry := builder.NewAccountDefEntryBuilder(string(conf.FrameworkPort), string(conf.FrameworkPort),
-			"Port for the Framework", ".*",
-			false, false).
-			Create()
-		acctDefProps = append(acctDefProps, frameworkPortAcctDefEntry)
-
-		// username
-		frameworkUserAcctDefEntry := builder.NewAccountDefEntryBuilder(string(conf.FrameworkUsername), string(conf.FrameworkUsername),
-			"Username for the framework", ".*",
-			false, false).
-			Create()
-		acctDefProps = append(acctDefProps, frameworkUserAcctDefEntry)
-
-		// password
-		frameworkPwdAcctDefEntry := builder.NewAccountDefEntryBuilder(string(conf.FrameworkPassword), string(conf.FrameworkPassword),
-			"Password for the framework", ".*",
-			false, true).
-			Create()
-		acctDefProps = append(acctDefProps, frameworkPwdAcctDefEntry)
-	}
-
-	// action ip
-	actionIPAcctDefEntry := builder.NewAccountDefEntryBuilder(string(conf.ActionIP), string(conf.ActionIP),
-		"IP of the action executor framework", ".*",
-		false, false).
-		Create()
-	acctDefProps = append(acctDefProps, actionIPAcctDefEntry)
-	// action port
-	actionPortAcctDefEntry := builder.NewAccountDefEntryBuilder(string(conf.ActionPort), string(conf.ActionPort),
-		"Port of the action executor framework", ".*",
-		false, false).
-		Create()
-	acctDefProps = append(acctDefProps, actionPortAcctDefEntry)
+	//if registrationClient.mesosMasterType == conf.Apache {
+	//	// framework id
+	//	frameworkIpAcctDefEntry := builder.NewAccountDefEntryBuilder(string(conf.FrameworkIP), string(conf.FrameworkIP),
+	//		"IP for the Framework", ".*",
+	//		false, false).
+	//		Create()
+	//	acctDefProps = append(acctDefProps, frameworkIpAcctDefEntry)
+	//
+	//	// framework port
+	//	frameworkPortAcctDefEntry := builder.NewAccountDefEntryBuilder(string(conf.FrameworkPort), string(conf.FrameworkPort),
+	//		"Port for the Framework", ".*",
+	//		false, false).
+	//		Create()
+	//	acctDefProps = append(acctDefProps, frameworkPortAcctDefEntry)
+	//
+	//	// username
+	//	frameworkUserAcctDefEntry := builder.NewAccountDefEntryBuilder(string(conf.FrameworkUsername), string(conf.FrameworkUsername),
+	//		"Username for the framework", ".*",
+	//		false, false).
+	//		Create()
+	//	acctDefProps = append(acctDefProps, frameworkUserAcctDefEntry)
+	//
+	//	// password
+	//	frameworkPwdAcctDefEntry := builder.NewAccountDefEntryBuilder(string(conf.FrameworkPassword), string(conf.FrameworkPassword),
+	//		"Password for the framework", ".*",
+	//		false, true).
+	//		Create()
+	//	acctDefProps = append(acctDefProps, frameworkPwdAcctDefEntry)
+	//}
 
 	return acctDefProps
 }

--- a/pkg/probe/registration_client_test.go
+++ b/pkg/probe/registration_client_test.go
@@ -87,7 +87,7 @@ func TestIdentifyingField(t *testing.T) {
 	masters = append(masters, conf.Apache)
 	masters = append(masters, conf.DCOS)
 
-	idField := conf.MasterIP
+	idField := conf.MasterIPPort
 	for _, masterType := range masters {
 		client := NewRegistrationClient(masterType)
 		assert.Equal(t, string(idField), client.GetIdentifyingFields())
@@ -113,9 +113,8 @@ func TestIdentifyingFieldInMesosAcctMap(t *testing.T) {
 func TestApacheMesosAccountMap(t *testing.T) {
 	client := NewRegistrationClient(conf.Apache)
 
-	expectedFields := [...]string {client.GetIdentifyingFields(), string(conf.MasterIP), string(conf.MasterPort),
-						string(conf.MasterUsername), string(conf.MasterPassword),
-					string(conf.FrameworkIP), string(conf.FrameworkPort)}
+	expectedFields := [...]string {client.GetIdentifyingFields(), string(conf.MasterIPPort),
+						string(conf.MasterUsername), string(conf.MasterPassword)}
 
 	var acctDefEntryMap map[string]*proto.AccountDefEntry
 	acctDefEntryMap = make(map[string]*proto.AccountDefEntry)
@@ -134,7 +133,7 @@ func TestApacheMesosAccountMap(t *testing.T) {
 func TestDCOSMesosAccountMap(t *testing.T) {
 	client := NewRegistrationClient(conf.DCOS)
 
-	expectedFields := [...]string {client.GetIdentifyingFields(), string(conf.MasterIP), string(conf.MasterPort),
+	expectedFields := [...]string {client.GetIdentifyingFields(), string(conf.MasterIPPort),
 		string(conf.MasterUsername), string(conf.MasterPassword)}
 	absentFields := [...]string {string(conf.FrameworkIP), string(conf.FrameworkPort)}
 


### PR DESCRIPTION
Change Mesos target configuration to accept a list of IP:Port for all the mesos master in the cluster and determine the leader during each discovery cycle before making REST API calls.
Support for Apache Mesos 1.2