### PR TITLE
Mesos Leader election support during discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,46 @@
+
+<p align="center">
+  <img src="https://cloud.githubusercontent.com/assets/4391815/26681386/05b857c4-46ab-11e7-8c71-15a46d886834.png">
+</p>
+
+
+<!--
+http://www.apache.org/licenses/LICENSE-2.0.txt
+
+
+Copyright 2015 Turbonomic
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
 # mesosturbo
+
+----
+
+1. [Overview](##Overview)
+2. [Getting Started](#getting-started)
+3. [Mesosturbo Use Cases](#use-cases)
+4. [Coming Soon](#coming-soon)
+
+----
+
+## Overview
+
+Mesosturbo leverages [Turbonomic](https://turbonomic.com/) patented analysis 
+engine to provide visibility and control across the entire stack of a Mesos Cluster,
+ to assure the performance of running micro-service in Mesos, as well as the efficiency of underlying infrastructure.
+
+Mesosturbo runs as a container on one of the Mesos Agent in a Mesos Cluster.
+Once Mesosturbo installed, it establishes communication with your existed Turbonomic server, to provide
+advanced application QoS control across the whole IT stack in real time by leveraging Turbonomic’s analysis engine.
+

--- a/cmd/conf-files/apache-mesos-target-conf-template.json
+++ b/cmd/conf-files/apache-mesos-target-conf-template.json
@@ -1,7 +1,6 @@
 {
   "master": "Apache Mesos",
-  "master-ip": "<Mesos Master IP>",
-  "master-port": "<Mesos Master Port>",
+  "master-ipport": "<Comma separated list of host and port of each Mesos Master in the cluster>",
   "master-user": "<Mesos Master Username>",
   "master-pwd": "<Mesos Master Password>"
 }

--- a/cmd/conf-files/dcos-target-conf-template.json
+++ b/cmd/conf-files/dcos-target-conf-template.json
@@ -1,7 +1,6 @@
 {
   "master": "Mesosphere DCOS",
-  "master-ip": "<Mesos Master IP>",
-  "master-port": "",
+  "master-ipport": "<Comma separated list of host and port of each Mesos Master in the cluster>",
   "master-user": "<Mesos Master Username>",
   "master-pwd": "<Mesos Master Password>"
 }

--- a/cmd/service/mesosturbo_service.go
+++ b/cmd/service/mesosturbo_service.go
@@ -16,19 +16,18 @@ import (
 
 // VMTServer has all the context and params needed to run a Scheduler
 type MesosTurboService struct {
-	LogVersion int
+	LogLevel           int
 	MesosMasterConfig  string	//path to the mesos master config
 	TurboCommConfig    string	// path to the turbo communication config file
 
 	// config for mesos
-	Master         string
-	MasterIP       string
-	MasterPort     string
-	MasterUsername string
-	MasterPassword string
+	Master             string
+	MasterIPPort       string
+	MasterUsername     string
+	MasterPassword     string
 
 	// config for turbo server
-	TurboServerUrl 	   string
+	TurboServerUrl     string
 	OpsManagerUsername string
 	OpsManagerPassword string
 }
@@ -41,13 +40,12 @@ func NewMesosTurboService() *MesosTurboService {
 
 // AddFlags adds flags for a specific VMTServer to the specified FlagSet
 func (s *MesosTurboService) AddFlags(fs *pflag.FlagSet) {
-	fs.IntVar(&s.LogVersion, "v", s.LogVersion, "Log level")
+	fs.IntVar(&s.LogLevel, "v", s.LogLevel, "Log level")
 	fs.StringVar(&s.MesosMasterConfig, "mesosconfig", s.MesosMasterConfig, "Path to the mesos config file.")
 	fs.StringVar(&s.TurboCommConfig, "turboconfig", s.TurboCommConfig, "Path to the turbo config flag.")
 
 	fs.StringVar(&s.Master, "mesostype", s.Master, "Mesos Master Type 'Apache Mesos'|'Mesosphere DCOS'")
-	fs.StringVar(&s.MasterIP, "masterip", s.MasterIP, "IP for the Mesos Master")
-	fs.StringVar(&s.MasterPort, "masterport", s.MasterPort, "Port for the Mesos Master")
+	fs.StringVar(&s.MasterIPPort, "masteripport", s.MasterIPPort, "Comma separated list of IP:port of each Mesos Master in the cluster")
 	fs.StringVar(&s.MasterUsername, "masteruser", s.MasterUsername, "User for the Mesos Master")
 	fs.StringVar(&s.MasterPassword, "masterpwd", s.MasterPassword, "Password for the Mesos Master")
 
@@ -67,6 +65,7 @@ func (s *MesosTurboService) Run(_ []string) error {
 	// ----------- Mesos Target Config
 	var mesosTargetConf *conf.MesosTargetConf
 	var mesosConfErr error
+
 	if targetConf != "" {
 		mesosTargetConf, mesosConfErr = conf.NewMesosTargetConf(targetConf)
 	} else {
@@ -81,14 +80,14 @@ func (s *MesosTurboService) Run(_ []string) error {
 		if (master == "") {
 			mesosConfErr = fmt.Errorf("Mesos Master Type is required")
 		}
-		if (s.MasterIP == "") {
-			mesosConfErr = fmt.Errorf("Mesos Master IP is required")
+
+		if (s.MasterIPPort == "") {
+			mesosConfErr = fmt.Errorf("Mesos Master IP::Port list is required")
 		}
 
 		mesosTargetConf = &conf.MesosTargetConf{
 			Master: master,
-			MasterIP: s.MasterIP,
-			MasterPort: s.MasterPort,
+			MasterIPPort: s.MasterIPPort,
 			MasterUsername: s.MasterUsername,
 			MasterPassword: s.MasterPassword,
 		}
@@ -138,11 +137,11 @@ func (s *MesosTurboService) Run(_ []string) error {
 	discoveryClient, err := discovery.NewDiscoveryClient(mesosMasterType, mesosTargetConf)
 
 	if err != nil {
-		glog.Errorf("Error creating discovery client for "+string(mesosMasterType)+"::"+mesosTargetConf.MasterIP+"\n", err.Error())
+		glog.Errorf("Error creating discovery client for "+string(mesosMasterType)+"::"+mesosTargetConf.MasterIPPort +"\n", err.Error())
 		os.Exit(1)
 	}
 
-	mesosTarget := mesosTargetConf.MasterIP
+	mesosTarget := mesosTargetConf.MasterIPPort
 	tapService, err :=
 		service.NewTAPServiceBuilder().
 			WithTurboCommunicator(turboCommConfigData).

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -3,37 +3,36 @@ Once deployed, the Mesosturbo service enables you to give Turbonomic visibility 
 
 ### Prerequisites
 * Turbonomic 5.9+
-* Running Mesos Apache or Mesosphere DCOS 1.8
+* Running Mesos Apache 1.2 or Mesosphere DCOS 1.8
 
 ### Step One: Deploying the Mesosturbo Docker Container Image
 > NOTE: Ensure that the Turbonomic Mesosturbo container image on DockerHub is accessible to the Marathon service in the Mesos Cluster.
 ##### Prerequisites 
 * Know your Mesos Master IP and port
 * Marathon service is available in the Mesos Cluster for deploying applications.
-* Marathon service has internet access to the DockerHub registry where the container image resides.
+* Marathon service has internet access to the DockerHub registry where the Turbonomic Mesosturbo container image resides.
 * Install Operations Manager 5.9+ and know its IP
 * Know the username and password for the Rest API user for Operations Manager.
 
 Containers are deployed by Marathon Service running in Mesos. 
 
-##### Mesosturbo Container Definition
+##### Mesosturbo Container Definition for deploying in Mesosphere DC/OS
 
-A copy of the deploy config can be downloaded from [here](deploy_mesosturbo_5.9_latest.json)
+A copy of the deploy config can be downloaded from [here](deploy_dcos_mesosturbo_5.9_0.json)
 
 ```yaml
 {
   "id": "mesosturbo",
   "container": {
     "docker": {
-      "image": "vmturbo/mesosturbo:5.9-latest"
+      "image": "vmturbo/mesosturbo:5.9.0"
     },
     "type": "DOCKER",
     "volumes": []
   },
   "args": [
-    "--mesostype", "<MESOS MASTER TYPE>",
-    "--masterip", "<MESOS-MASTER-IP>"
-    "--masterport", "<MESOS-MASTER-PORT>",
+    "--mesostype", "Mesosphere DCOS",
+    "--masteripport", "<MESOS-MASTER-IPPORT>",
     "--masteruser", "<MESOS-MASTER-USER>",
     "--masterpwd", "<MESOS-MASTER-PASSWORD>",
     "--turboserverurl", "http://<TURBO-OPERATIONS-MANAGER-IP>:80",
@@ -45,18 +44,48 @@ A copy of the deploy config can be downloaded from [here](deploy_mesosturbo_5.9_
   "instances": 1
 }
 ```
-
 > Replace 
-> * \<MESOS MASTER TYPE> with 
->   * "Mesosphere DCOS" for Mesosphere DC/OS 
->   * "Apache Mesos" for Apache Mesos
-> * \<MESOS-MASTER-IP> with IP address for the Mesos Master
-> * \<MESOS-MASTER-PORT> with the port for the Mesos Master
+> * \<MESOS-MASTER-IPPORT> with the Comma separated list of host and port of each Mesos Master in the cluster, 
+ e.g. 1.1.1.100,1.1.1.101,1.1.1.102
 > * \<MESOS-MASTER-USER> with the Username for the Mesos Master
 > * \<MESOS-MASTER-PASSWORD> with the Password for the Mesos Master
 > * \<TURBO-OPERATIONS-MANAGER-IP> with the IP address for the Turbo Operations Manager
 > * \<TURBO-OPERATIONS-MANAGER-ADMIN-USERNAME> with the username for the administrator user in the Turbo Operations Manager
 > * \<TURBO-OPERATIONS-MANAGER-ADMIN-PASSWORD> with the password for the administrator user in the Turbo Operations Manager
+
+##### Mesosturbo Container Definition for deploying in Apache Mesos
+
+A copy of the deploy config can be downloaded from [here](deploy_apache_mesosturbo_5.9_0.json)
+
+```yaml
+{
+  "id": "mesosturbo",
+  "container": {
+    "docker": {
+      "image": "vmturbo/mesosturbo:5.9.0"
+    },
+    "type": "DOCKER",
+    "volumes": []
+  },
+  "args": [
+    "--mesostype", "Apache Mesos",
+    "--masteripport", "<MESOS-MASTER-IPPORT>",
+    "--turboserverurl", "http://<TURBO-OPERATIONS-MANAGER-IP>:80",
+    "--opsmanagerusername", "<TURBO-OPERATIONS-MANAGER-ADMIN-USERNAME>",
+    "--opsmanagerpassword", "<TURBO-OPERATIONS-MANAGER-ADMIN-PASSWORD>" 
+  ],
+  "cpus": 0.5,
+  "mem": 128.0,
+  "instances": 1
+}
+```
+> Replace 
+> * \<MESOS-MASTER-IPPORT> with the Comma separated list of host and port of each Mesos Master in the cluster,
+ e.g. 1.1.1.100:5050,1.1.1.101:5050,1.1.1.102:5050. *Omit port if using default port 5050*.
+> * \<TURBO-OPERATIONS-MANAGER-IP> with the IP address for the Turbo Operations Manager
+> * \<TURBO-OPERATIONS-MANAGER-ADMIN-USERNAME> with the username for the administrator user in the Turbo Operations Manager
+> * \<TURBO-OPERATIONS-MANAGER-ADMIN-PASSWORD> with the password for the administrator user in the Turbo Operations Manager
+
 
 The Mesosturbo container will be visible after several seconds. 
 

--- a/deploy/deploy_apache_mesosturbo_5.9_0.json
+++ b/deploy/deploy_apache_mesosturbo_5.9_0.json
@@ -2,17 +2,14 @@
   "id": "mesosturbo",
   "container": {
     "docker": {
-      "image": "vmturbo/mesosturbo:5.9-latest"
+      "image": "vmturbo/mesosturbo:5.9.0"
     },
     "type": "DOCKER",
     "volumes": []
   },
   "args": [
     "--mesostype", "Apache Mesos",
-    "--masterip", "<MESOS-MASTER-IP>",
-    "--masterport", "<MESOS-MASTER-PORT>",
-    "--masteruser", "<MESOS-MASTER-USER>",
-    "--masterpwd", "<MESOS-MASTER-PASSWORD>",
+    "--masteripport", "<MESOS-MASTER-IPPORT>",
     "--turboserverurl", "http://<TURBO-OPERATIONS-MANAGER-IP>:80",
     "--opsmanagerusername", "<TURBO-OPERATIONS-MANAGER-ADMIN-USERNAME>",
     "--opsmanagerpassword", "<TURBO-OPERATIONS-MANAGER-ADMIN-PASSWORD>"

--- a/deploy/deploy_dcos_mesosturbo_5.9_0.json
+++ b/deploy/deploy_dcos_mesosturbo_5.9_0.json
@@ -2,15 +2,14 @@
   "id": "mesosturbo",
   "container": {
     "docker": {
-      "image": "vmturbo/mesosturbo:5.9-latest"
+      "image": "vmturbo/mesosturbo:5.9.0"
     },
     "type": "DOCKER",
     "volumes": []
   },
   "args": [
     "--mesostype", "Mesosphere DCOS",
-    "--masterip", "<MESOS-MASTER-IP>",
-    "--masterport", "<MESOS-MASTER-PORT>",
+    "--masteripport", "<MESOS-MASTER-IPPORT>",
     "--masteruser", "<MESOS-MASTER-USER>",
     "--masterpwd", "<MESOS-MASTER-PASSWORD>",
     "--turboserverurl", "http://<TURBO-OPERATIONS-MANAGER-IP>:80",

--- a/pkg/conf/mesos_target_conf_test.go
+++ b/pkg/conf/mesos_target_conf_test.go
@@ -14,21 +14,19 @@ func TestEmptyConfig(t *testing.T) {
 	assert.Equal(t, false, bool, fmt.Sprintf("Validation should fail for empty config : %s", err))
 }
 
-func TestMissingMasterIP(t *testing.T) {
+func TestMissingMasterIPPort(t *testing.T) {
 	conf := &MesosTargetConf{
-		MasterPort:     "8080",
 		MasterUsername: "user",
 		MasterPassword: "pwd",
 	}
 	bool, err := conf.validate()
 
-	assert.Equal(t, false, bool, fmt.Sprintf("Validation should fail for empty MasterIP : %s", err))
+	assert.Equal(t, false, bool, fmt.Sprintf("Validation should fail for empty MasterIPPort : %s", err))
 }
 
 func TestMissingMasterType(t *testing.T) {
 	conf := &MesosTargetConf{
-		MasterIP:       "127.0.0.1",
-		MasterPort:     "8080",
+		MasterIPPort:       "127.0.0.1:5050",
 		MasterUsername: "user",
 		MasterPassword: "pwd",
 	}
@@ -42,8 +40,7 @@ func TestMissingMasterType(t *testing.T) {
 func TestGetAccountFields(t *testing.T) {
 	conf := &MesosTargetConf{
 		Master:         Apache,
-		MasterIP:       "127.0.0.1",
-		MasterPort:     "8080",
+		MasterIPPort:       "127.0.0.1:5050",
 		MasterUsername: "user",
 		MasterPassword: "pwd",
 	}
@@ -56,8 +53,7 @@ func TestGetAccountFields(t *testing.T) {
 		acctValuesMap[acctVal.GetKey()] = acctVal
 	}
 
-	checkAccountValueField(t, acctValuesMap[string(MasterIP)], string(MasterIP), conf.MasterIP)
-	checkAccountValueField(t, acctValuesMap[string(MasterPort)], string(MasterPort), conf.MasterPort)
+	checkAccountValueField(t, acctValuesMap[string(MasterIPPort)], string(MasterIPPort), conf.MasterIPPort)
 	checkAccountValueField(t, acctValuesMap[string(MasterUsername)], string(MasterUsername), conf.MasterUsername)
 	checkAccountValueField(t, acctValuesMap[string(MasterPassword)], string(MasterPassword), conf.MasterPassword)
 }
@@ -79,19 +75,11 @@ func TestCreateMesosTargetConf(t *testing.T) {
 
 func createApacheAccValues() []*proto.AccountValue {
 	var accountValues []*proto.AccountValue
-	prop1 := string(MasterIP)
-	val1 := "10.10.10.10"
+	prop1 := string(MasterIPPort)
+	val1 := "10.10.10.10:5050"
 	accVal := &proto.AccountValue{
 		Key:         &prop1,
 		StringValue: &val1,
-	}
-	accountValues = append(accountValues, accVal)
-
-	prop2 := string(MasterPort)
-	val2 := "5050"
-	accVal = &proto.AccountValue{
-		Key:         &prop2,
-		StringValue: &val2,
 	}
 	accountValues = append(accountValues, accVal)
 

--- a/pkg/conf/probe_constants.go
+++ b/pkg/conf/probe_constants.go
@@ -28,8 +28,7 @@ const (
 type ProbeAcctDefEntryName string
 
 const (
-	MasterIP       ProbeAcctDefEntryName = "MasterIP"
-	MasterPort     ProbeAcctDefEntryName = "MasterPort"
+	MasterIPPort   	ProbeAcctDefEntryName = "MasterIPPort"
 	MasterUsername ProbeAcctDefEntryName = "Username"
 	MasterPassword ProbeAcctDefEntryName = "Password"
 
@@ -37,7 +36,4 @@ const (
 	FrameworkPort     ProbeAcctDefEntryName = "FrameworkPort"
 	FrameworkUsername ProbeAcctDefEntryName = "FrameworkUsername"
 	FrameworkPassword ProbeAcctDefEntryName = "FrameworkPassword"
-
-	ActionIP   ProbeAcctDefEntryName = "ActionIP"
-	ActionPort ProbeAcctDefEntryName = "ActionPort"
 )

--- a/pkg/data/mesos_master.go
+++ b/pkg/data/mesos_master.go
@@ -7,6 +7,7 @@ import (
 type MesosMaster struct {
 	Id     string
 	Leader string
+	Pid    string
 	//cluster
 	Cluster      ClusterInfo
 	AgentMap     map[string]*Agent

--- a/pkg/data/types.go
+++ b/pkg/data/types.go
@@ -1,16 +1,32 @@
 package data
 
+
 type MesosAPIResponse struct {
 	Leader      string `json:"leader"`
+	LeaderInfo Leader `json:"leader_info"`
+	//LeaderInfo struct {
+	//		   Id string `json:"id"`
+	//		   Pid string `json:"pid"`
+	//		   Port  int `json:"port"`
+	//		   Hostname string `json:"hostname"`
+	//       } `json:"leader_info"`
 	Version     string `json:"version"`
 	Id          string `json:"id"`
 	ClusterName string `json:"cluster"`
-
-	ActivatedSlaves   float64     `json:"activated_slaves"`
-	DeActivatedSlaves float64     `json:"deactivated_slaves"`
+	Pid 	string `json:"pid"`
+	//ActivatedSlaves   float64     `json:"activated_slaves"`
+	//DeActivatedSlaves float64     `json:"deactivated_slaves"`
 	Agents            []Agent     `json:"slaves"`
 	Frameworks        []Framework `json:"frameworks"`
 }
+
+type Leader struct {
+	Id string `json:"id"`
+	Pid string `json:"pid"`
+	Port  int `json:"port"`
+	Hostname string `json:"hostname"`
+}
+
 type Agent struct {
 	Id               string    `json:"id"`
 	Pid              string    `json:"pid"`
@@ -21,12 +37,12 @@ type Agent struct {
 	Name             string    `json:"hostname"`
 	//Calculated       CalculatedUse
 	//Attributes       Attributes `json:"attributes"`
-	Active  bool   `json:"active"`
-	Version string `json:"version"`
+	Active           bool   `json:"active"`
+	Version          string `json:"version"`
 	// -------- Computed parameters
-	ClusterName string
+	ClusterName      string
 	IP               string // parsed ip for the Slave
-	Port             string
+	PortNum          string
 	ResourceUseStats *CalculatedUse
 	TaskMap          map[string]*Task
 }

--- a/pkg/discovery/mesos_leader.go
+++ b/pkg/discovery/mesos_leader.go
@@ -1,0 +1,244 @@
+package discovery
+
+import (
+	"github.com/turbonomic/mesosturbo/pkg/conf"
+	master "github.com/turbonomic/mesosturbo/pkg/masterapi"
+	"fmt"
+	"strings"
+	"github.com/golang/glog"
+	"github.com/turbonomic/mesosturbo/pkg/data"
+	"strconv"
+)
+
+
+type MASTER_IP_PORT string
+// Structure representing the Master acts as the leader in the cluster
+type MesosLeader struct {
+	// Mesos Target configuration provided to the mesosturbo service
+	targetConf       *conf.MesosTargetConf
+
+	// Map of master IP:Port and the configuration for that master
+	masterConfMap map[MASTER_IP_PORT]*conf.MasterConf
+
+	// The mesos state response
+	MasterState      *data.MesosAPIResponse
+
+	// Configuration of the current leader in the cluster
+	leaderConf	*conf.MasterConf
+	// Rest API Client for the current leader in the cluster
+	leaderRestClient master.MasterRestClient
+}
+
+// Create new instance of MesosLeader using the given target Conf that contains
+// the list of IP:Port and credentials for login for each master
+func NewMesosLeader(targetConf *conf.MesosTargetConf) (*MesosLeader, error) {
+	glog.V(3).Infof("Creating mesos leader %++v", targetConf)
+
+	// Create the Mesos leader
+	mesosLeader := &MesosLeader{}
+	mesosLeader.targetConf = targetConf
+	mesosLeader.masterConfMap = make(map[MASTER_IP_PORT]*conf.MasterConf)
+
+	// Parse the list of IP:Port into an array of MasterSerivceConf
+	confList := parseMasterIPPorts(targetConf.Master, targetConf.MasterIPPort)
+	for _, masterConf := range confList {
+		mapkey := strings.Join([]string{masterConf.MasterIP, masterConf.MasterPort}, ":")
+		mesosLeader.masterConfMap[MASTER_IP_PORT(mapkey)] = masterConf
+	}
+
+	// Detect the leader by iterating over the list of IP:Port
+	err := mesosLeader.updateMesosLeader()
+	if err != nil {
+		return nil, err
+	}
+	return mesosLeader, err
+}
+
+// Routine to detect the leader by logging and issuing the get state rest api call
+func (mesosLeader *MesosLeader) updateMesosLeader() (error){
+	// The target info originally created by the probe
+	targetConf := mesosLeader.targetConf
+	glog.V(3).Infof("Detecting mesos master leader from %s", targetConf.MasterIPPort)
+
+	// Create the Mesos leader by iterating over the list of IP:Port
+	for _, masterConf := range mesosLeader.masterConfMap {
+		glog.Infof("Checking master conf : %s\n", masterConf)
+
+		// Get RestAPIClient for this master and login
+		var masterRestClient master.MasterRestClient
+		masterRestClient, err := mesosLeader.getRestAPIClient(targetConf, masterConf)
+		if err != nil { // can't login, skip this one - dcos
+			glog.Errorf("Error creating rest api client : %s", err)
+			continue
+		}
+		// API request to get the Master State to get the leader
+		mesosState, err := masterRestClient.GetState()
+		if err != nil { // can't get state, skip this one - apache
+			glog.Errorf("Error getting state from master %s::%s : %s \n",
+					masterConf.MasterIP, masterConf.MasterPort, err)
+			continue
+		}
+		glog.V(3).Infof("Mesos api succeeded for: %++v\n", mesosState.LeaderInfo)
+		if  mesosState.LeaderInfo.Hostname == "" {
+			glog.V(3).Infof("Missing leader info in state response from master  %s::%s : %s \n",
+					masterConf.MasterIP, masterConf.MasterPort, err)
+			//continue;
+			mesosLeader.leaderConf = masterConf
+			mesosLeader.leaderRestClient = masterRestClient
+			mesosLeader.MasterState = mesosState	// state retrieved
+			glog.V(3).Infof("Using mesos leader: %s::%s\n",
+				mesosLeader.leaderConf.MasterIP, mesosLeader.leaderConf.MasterPort)
+			return nil
+		}
+		// Compare leader IP to current master
+		if mesosState.LeaderInfo.Hostname == masterConf.MasterIP {
+			// Leader is same as the current master
+			mesosLeader.leaderConf = masterConf
+			mesosLeader.leaderRestClient = masterRestClient
+			glog.V(3).Infof("Leader is same as the current master %s::%s",
+					mesosLeader.leaderConf.MasterIP, mesosLeader.leaderConf.MasterPort)
+		} else {
+			// Leader is different from the current master
+			portStr := strconv.Itoa(mesosState.LeaderInfo.Port)
+			mapkey := strings.Join([]string{mesosState.LeaderInfo.Hostname, portStr}, ":")
+			leaderConf, exists := mesosLeader.masterConfMap[MASTER_IP_PORT(mapkey)]
+			if !exists { // edge case that the target conf is missing the leader service ip:port
+				leaderConf = &conf.MasterConf {
+					MasterIP:mesosState.LeaderInfo.Hostname,
+					MasterPort:portStr,
+				}
+				glog.V(2).Infof("Missing conf for the leader %s, created new leaderconf %++v", mapkey, leaderConf)
+				mesosLeader.masterConfMap[MASTER_IP_PORT(mapkey)] = leaderConf
+			}
+			mesosLeader.leaderConf = leaderConf
+			glog.V(3).Infof("Leader is differnt than the current master %s::%s",
+				mesosLeader.leaderConf.MasterIP, mesosLeader.leaderConf.MasterPort)
+			// get the api client and save it
+			leaderRestClient, _ := mesosLeader.getRestAPIClient(targetConf, leaderConf)
+			mesosLeader.leaderRestClient = leaderRestClient
+		}
+
+		mesosLeader.MasterState = mesosState	// state retrieved
+		glog.Infof("Detected mesos leader: %s::%s\n",
+				mesosLeader.leaderConf.MasterIP, mesosLeader.leaderConf.MasterPort)
+		return nil
+	}
+	return fmt.Errorf("Cannot detect leader using %s", targetConf.MasterIPPort)
+}
+
+
+// Refresh the Mesos leader state
+// Use existing RestAPI client to execute the request or update the leader and execute the request
+func (mesosLeader *MesosLeader) RefreshMesosLeaderState() (error) {
+	glog.V(3).Infof("RefreshMesosLeaderState %++v", mesosLeader.leaderConf)
+	// API request to get the Master State from the current leader
+	mesosState, err := mesosLeader.leaderRestClient.GetState()
+	if err == nil { // no error, succeeded but check the leader
+		glog.V(3).Infof("Mesos get state api succeeded with existing leader : %++v\n",
+					mesosLeader.leaderConf)
+		// Leader is same as the current leader, then update the Master State and return
+		if mesosState.LeaderInfo.Hostname == mesosLeader.leaderConf.MasterIP {
+			mesosLeader.MasterState = mesosState
+			glog.V(3).Infof("No change in mesos leader : %++v\n", mesosLeader.leaderConf)
+			return nil
+		}
+	}
+
+	// Create the new leader by iterating over the list of master service configs
+	glog.Errorf("Existing leader at %s is not reachable, detecting new leader using : %s",
+				mesosLeader.leaderConf.MasterIP, mesosLeader.targetConf.MasterIPPort)
+
+	// Create the Mesos leader by iterating over the list of IP:Port
+	err = mesosLeader.updateMesosLeader()
+	return err
+}
+
+// Refresh the Mesos leader login
+// Use existing leader RestAPI client to execute the request, if not successful update the leader and login again
+func (mesosLeader *MesosLeader) RefreshMesosLeaderLogin() (error) {
+	glog.V(3).Infof("RefreshMesosLeaderLogin %++v", mesosLeader.leaderConf)
+	// API request to Login to the current Mesos Master leader and save the login token for subsequent discovery requests
+	token, err := mesosLeader.leaderRestClient.Login()
+	if err == nil {
+		glog.V(3).Infof("Mesos login api succeeded with existing leader : %++v\n", mesosLeader.leaderConf)
+		mesosLeader.leaderConf.Token = token
+		return nil
+	}
+
+	glog.Errorf("Error logging to Mesos Leader at %s, detecting new leader using : %s",
+			mesosLeader.leaderConf.MasterIP, mesosLeader.targetConf.MasterIPPort)
+	// Refresh the leader
+	err = mesosLeader.updateMesosLeader()
+	return err
+}
+
+// Get the RestAPI Client using the given master config.
+// Return MasterRestClient if login is successful, nil if the login fails
+func (mesosLeader *MesosLeader) getRestAPIClient(targetConf *conf.MesosTargetConf, masterConf *conf.MasterConf) (master.MasterRestClient,  error) {
+	// Bad master config
+	if masterConf.MasterIP == "" {
+		return nil, fmt.Errorf("Null master ip : " + string(targetConf.Master))
+	}
+	var masterRestClient master.MasterRestClient
+
+	// supply credentials from the target conf before creating the login request
+	masterConf.MasterUsername = targetConf.MasterUsername
+	masterConf.MasterPassword = targetConf.MasterPassword
+	masterConf.Master = targetConf.Master
+	glog.V(3).Infof("Creating new master rest api client %++v", masterConf)
+	// Create a new rest api client using the given master conf
+	masterRestClient = master.GetMasterRestClient(targetConf.Master, masterConf)
+
+	if masterRestClient == nil {	//does not exist and cannot create new instance
+		nerr := fmt.Errorf("Cannot find rest api client for master %s:%s::%s ", string(targetConf.Master))
+		glog.Errorf("%s", nerr.Error())
+		return nil, nerr
+	}
+
+	// Login to the Mesos Master and save the login token
+	token, err := masterRestClient.Login()
+	if err != nil {
+		nerr := fmt.Errorf("Error logging to mesos master at %s::%s : %s ",
+			masterConf.MasterIP, masterConf.MasterPort, err)
+		glog.Errorf("%s", nerr.Error())
+		return nil, nerr
+	}
+	// Save the token
+	masterConf.Token = token
+	return masterRestClient, nil
+}
+
+func parseMasterIPPorts(masterType conf.MesosMasterType, ipportlist string) []*conf.MasterConf {
+	// Split on comma.
+	ipports := strings.Split(ipportlist, ",")
+
+	var masterConfList []*conf.MasterConf
+	for i := range ipports {
+		result := strings.Split(ipports[i], ":")
+		var ipaddress, port string
+		ipaddress = strings.TrimSpace(result[0])
+		if ipaddress == "" {
+			continue
+		}
+
+		if len(result) < 2 {
+			if masterType== conf.Apache {
+				port = conf.DEFAULT_APACHE_MESOS_MASTER_PORT
+			} else if masterType== conf.DCOS {
+				port = conf.DEFAULT_DCOS_MESOS_MASTER_PORT
+			} else {
+				port = ""
+			}
+		} else {
+			port = strings.TrimSpace(result[1])
+		}
+		glog.Infof("[MesosLeader] parsed ipport %s::%s",ipaddress, port)
+		masterConf := &conf.MasterConf {
+			MasterIP:ipaddress,
+			MasterPort:port,
+		}
+		masterConfList = append(masterConfList, masterConf)
+	}
+	return masterConfList
+} //end
+

--- a/pkg/masterapi/agent_rest_api.go
+++ b/pkg/masterapi/agent_rest_api.go
@@ -29,8 +29,9 @@ type AgentEndpointStore struct {
 // ==========================================================================
 // Represents the generic client used to connect to a Agent
 type GenericAgentAPIClient struct {
-	MasterConf *conf.MesosTargetConf
-	// Mesos target configuration
+	// Master service configuration
+	MasterConf    *conf.MasterConf
+	// Mesos Agent configuration
 	AgentConf     *conf.AgentConf
 	// Endpoint store with the endpoint paths for different rest api calls
 	EndpointStore *AgentEndpointStore
@@ -42,9 +43,9 @@ type GenericAgentAPIClient struct {
 // Create a new instance of the GenericMasterAPIClient
 // @param AgentConf the conf.AgentConf that contains the configuration information for the Agent
 // @param epStore    the Endpoint store containing the Rest API endpoints for the Agent
-func NewGenericAgentAPIClient(agentConf *conf.AgentConf, mesosConf *conf.MesosTargetConf, epStore *AgentEndpointStore) *GenericAgentAPIClient{
+func NewGenericAgentAPIClient(agentConf *conf.AgentConf, masterConf *conf.MasterConf, epStore *AgentEndpointStore) *GenericAgentAPIClient{
 	return &GenericAgentAPIClient{
-		MasterConf: mesosConf,
+		MasterConf: masterConf,
 		AgentConf:     agentConf,
 		EndpointStore: epStore,
 	}
@@ -58,7 +59,7 @@ func (agentRestClient *GenericAgentAPIClient) GetStats() ([]data.Executor, error
 	// Execute request
 	endpoint, _ := agentRestClient.EndpointStore.EndpointMap[Stats]
 	request, err := createRequest(endpoint.EndpointPath,
-					agentRestClient.AgentConf.AgentIP,  agentRestClient.AgentConf.AgentPort,
+					agentRestClient.AgentConf.AgentIP, string(agentRestClient.AgentConf.AgentPort),
 					agentRestClient.MasterConf.Token)
 	if err != nil {
 		return nil, ErrorCreateRequest(AgentAPIClientClass, err)

--- a/pkg/masterapi/factory.go
+++ b/pkg/masterapi/factory.go
@@ -10,7 +10,7 @@ import (
 // Interface for the client to handle Rest API communication with the Mesos Master
 type MasterRestClient interface {
 	Login() (string, error)
-	GetState() (*data.MesosAPIResponse, error)	//(*MesosState, error)
+	GetState() (*data.MesosAPIResponse, error)
 }
 
 // Interface for the client to handle Rest API communication with the Agent
@@ -19,7 +19,8 @@ type AgentRestClient interface {
 }
 
 // Get the Rest API client to handle communication with the Mesos Master
-func GetMasterRestClient(mesosType conf.MesosMasterType, mesosConf *conf.MesosTargetConf) MasterRestClient {
+// Returns the MasterRestClient for the supported specific Mesos vendor type, else nil
+func GetMasterRestClient(mesosType conf.MesosMasterType, masterConf *conf.MasterConf) MasterRestClient {
 	var endpointStore *MasterEndpointStore
 	if mesosType == conf.Apache {
 		glog.V(2).Infof("[GetMasterRestClient] Creating Apache Mesos Master Client")
@@ -34,11 +35,12 @@ func GetMasterRestClient(mesosType conf.MesosMasterType, mesosConf *conf.MesosTa
 		return nil
 	}
 
-	return NewGenericMasterAPIClient(mesosConf, endpointStore)
+	return NewGenericMasterAPIClient(masterConf, endpointStore)
 }
 
 // Get the Rest API client to handle communication with the Agent
-func GetAgentRestClient(mesosType conf.MesosMasterType, agentConf *conf.AgentConf, mesosConf *conf.MesosTargetConf) AgentRestClient {
+// Returns the AgentRestClient for the supported specific Mesos vendor type, else nil
+func GetAgentRestClient(mesosType conf.MesosMasterType, agentConf *conf.AgentConf, masterConf *conf.MasterConf) AgentRestClient {
 	var endpointStore *AgentEndpointStore
 	if mesosType == conf.Apache {
 		glog.V(2).Infof("[GetAgentRestClient] Creating Apache Agent Client")
@@ -53,7 +55,7 @@ func GetAgentRestClient(mesosType conf.MesosMasterType, agentConf *conf.AgentCon
 		return nil
 	}
 
-	return NewGenericAgentAPIClient(agentConf, mesosConf, endpointStore)
+	return NewGenericAgentAPIClient(agentConf, masterConf, endpointStore)
 }
 
 

--- a/pkg/probe/registration_client.go
+++ b/pkg/probe/registration_client.go
@@ -131,7 +131,7 @@ func (registrationClient *MesosRegistrationClient) GetSupplyChainDefinition() []
 }
 
 func (registrationClient *MesosRegistrationClient) GetIdentifyingFields() string {
-	return string(conf.MasterIP)
+	return string(conf.MasterIPPort)
 }
 
 // The return type is a list of ProbeInfo_AccountDefProp.
@@ -140,19 +140,12 @@ func (registrationClient *MesosRegistrationClient) GetIdentifyingFields() string
 func (registrationClient *MesosRegistrationClient) GetAccountDefinition() []*proto.AccountDefEntry {
 	var acctDefProps []*proto.AccountDefEntry
 
-	// master ip
-	targetIDAcctDefEntry := builder.NewAccountDefEntryBuilder(string(conf.MasterIP), string(conf.MasterIP),
-		"IP of the mesos master", ".*",
+	// master ip port list
+	masterIPListAcctDefEntry := builder.NewAccountDefEntryBuilder(string(conf.MasterIPPort), string(conf.MasterIPPort),
+		"Comma separated list of `host:port` for each Mesos Master in the cluster", ".*",
 		true, false).
 		Create()
-	acctDefProps = append(acctDefProps, targetIDAcctDefEntry)
-
-	// master port
-	masterPortAcctDefEntry := builder.NewAccountDefEntryBuilder(string(conf.MasterPort), string(conf.MasterPort),
-		"Port of the mesos master", ".*",
-		false, false).
-		Create()
-	acctDefProps = append(acctDefProps, masterPortAcctDefEntry)
+	acctDefProps = append(acctDefProps, masterIPListAcctDefEntry)
 
 	// username
 	usernameAcctDefEntry := builder.NewAccountDefEntryBuilder(string(conf.MasterUsername), string(conf.MasterUsername),
@@ -167,49 +160,6 @@ func (registrationClient *MesosRegistrationClient) GetAccountDefinition() []*pro
 		false, true).
 		Create()
 	acctDefProps = append(acctDefProps, passwdAcctDefEntry)
-
-	if registrationClient.mesosMasterType == conf.Apache {
-		// framework id
-		frameworkIpAcctDefEntry := builder.NewAccountDefEntryBuilder(string(conf.FrameworkIP), string(conf.FrameworkIP),
-			"IP for the Framework", ".*",
-			false, false).
-			Create()
-		acctDefProps = append(acctDefProps, frameworkIpAcctDefEntry)
-
-		// framework port
-		frameworkPortAcctDefEntry := builder.NewAccountDefEntryBuilder(string(conf.FrameworkPort), string(conf.FrameworkPort),
-			"Port for the Framework", ".*",
-			false, false).
-			Create()
-		acctDefProps = append(acctDefProps, frameworkPortAcctDefEntry)
-
-		// username
-		frameworkUserAcctDefEntry := builder.NewAccountDefEntryBuilder(string(conf.FrameworkUsername), string(conf.FrameworkUsername),
-			"Username for the framework", ".*",
-			false, false).
-			Create()
-		acctDefProps = append(acctDefProps, frameworkUserAcctDefEntry)
-
-		// password
-		frameworkPwdAcctDefEntry := builder.NewAccountDefEntryBuilder(string(conf.FrameworkPassword), string(conf.FrameworkPassword),
-			"Password for the framework", ".*",
-			false, true).
-			Create()
-		acctDefProps = append(acctDefProps, frameworkPwdAcctDefEntry)
-	}
-
-	// action ip
-	actionIPAcctDefEntry := builder.NewAccountDefEntryBuilder(string(conf.ActionIP), string(conf.ActionIP),
-		"IP of the action executor framework", ".*",
-		false, false).
-		Create()
-	acctDefProps = append(acctDefProps, actionIPAcctDefEntry)
-	// action port
-	actionPortAcctDefEntry := builder.NewAccountDefEntryBuilder(string(conf.ActionPort), string(conf.ActionPort),
-		"Port of the action executor framework", ".*",
-		false, false).
-		Create()
-	acctDefProps = append(acctDefProps, actionPortAcctDefEntry)
 
 	return acctDefProps
 }

--- a/pkg/probe/registration_client_test.go
+++ b/pkg/probe/registration_client_test.go
@@ -87,7 +87,7 @@ func TestIdentifyingField(t *testing.T) {
 	masters = append(masters, conf.Apache)
 	masters = append(masters, conf.DCOS)
 
-	idField := conf.MasterIP
+	idField := conf.MasterIPPort
 	for _, masterType := range masters {
 		client := NewRegistrationClient(masterType)
 		assert.Equal(t, string(idField), client.GetIdentifyingFields())
@@ -113,9 +113,8 @@ func TestIdentifyingFieldInMesosAcctMap(t *testing.T) {
 func TestApacheMesosAccountMap(t *testing.T) {
 	client := NewRegistrationClient(conf.Apache)
 
-	expectedFields := [...]string {client.GetIdentifyingFields(), string(conf.MasterIP), string(conf.MasterPort),
-						string(conf.MasterUsername), string(conf.MasterPassword),
-					string(conf.FrameworkIP), string(conf.FrameworkPort)}
+	expectedFields := [...]string {client.GetIdentifyingFields(), string(conf.MasterIPPort),
+						string(conf.MasterUsername), string(conf.MasterPassword)}
 
 	var acctDefEntryMap map[string]*proto.AccountDefEntry
 	acctDefEntryMap = make(map[string]*proto.AccountDefEntry)
@@ -134,7 +133,7 @@ func TestApacheMesosAccountMap(t *testing.T) {
 func TestDCOSMesosAccountMap(t *testing.T) {
 	client := NewRegistrationClient(conf.DCOS)
 
-	expectedFields := [...]string {client.GetIdentifyingFields(), string(conf.MasterIP), string(conf.MasterPort),
+	expectedFields := [...]string {client.GetIdentifyingFields(), string(conf.MasterIPPort),
 		string(conf.MasterUsername), string(conf.MasterPassword)}
 	absentFields := [...]string {string(conf.FrameworkIP), string(conf.FrameworkPort)}
 


### PR DESCRIPTION
Tested using Apache Mesos 1.2 and 3 master node cluster.
- Configure the mesosturbo service using the list of master node IPs
- Issue the get state request to the first IP in the list, if that succeeds, get the leader ip and save the new leader conf for subsequent requests
- For the next discovery cycles use the leader IP to get the state
- If this fails, only then  iterate over the IP list again to detect the new leader